### PR TITLE
Makefile: clean up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,11 @@ CXX=g++
 NAME:=libsocket-can-java
 
 ### JAVA_HOME
-JAVA_HOME=$(shell readlink -f /usr/bin/javac | sed "s:bin/javac::")
+ifndef JAVA_HOME
+	JAVA_HOME=$(shell readlink -f /usr/bin/javac | sed "s:bin/javac::")
+endif
 
-JAVA_INCLUDES=-I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux
+JAVA_INCLUDES=-I$(JAVA_HOME)/include
 JAVA=$(JAVA_HOME)/bin/java
 JAVAC=$(JAVA_HOME)/bin/javac
 JAVAH=$(JAVA_HOME)/bin/javah
@@ -18,13 +20,13 @@ JAVA_TEST_DEST=classes.test
 LIB_DEST=lib
 JAR_DEST=dist
 JAR_DEST_FILE=$(JAR_DEST)/$(NAME).jar
-DIRS=stamps $(JAVA_DEST) $(JAVA_TEST_DEST) $(LIB_DEST) $(JAR_DEST)
+DIRS=stamps obj $(JAVA_DEST) $(JAVA_TEST_DEST) $(LIB_DEST) $(JAR_DEST)
 JNI_DIR=jni
 JNI_CLASSES=de.entropia.can.CanSocket
 JAVAC_FLAGS=-g -Xlint:all
 CXXFLAGS=-I./include -O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions \
 -fstack-protector --param=ssp-buffer-size=4 -fPIC \
--Wall -pedantic -std=gnu++11 -D_REENTRANT -D_GNU_SOURCE \
+-pedantic -std=gnu++11 -D_REENTRANT -D_GNU_SOURCE \
 $(JAVA_INCLUDES)
 SONAME=jni_socketcan
 LDFLAGS=-Wl,-soname,$(SONAME)


### PR DESCRIPTION
Remove double -Wall.

Remove include/linux - include/ is sufficient.

Add 'obj' folder to the clean target.

Take JAVA_HOME environment variable for the systems with more
than one JDK instance installed.

Signed-off-by: Yegor Yefremov yegorslists@googlemail.com
