### PR TITLE
Fix close() issue

### DIFF
--- a/jni/cansocket.cpp
+++ b/jni/cansocket.cpp
@@ -95,7 +95,7 @@ JNIEXPORT jint JNICALL Java_de_entropia_can_CanSocket__1openSocketBCM
 }
 
 JNIEXPORT void JNICALL Java_de_entropia_can_CanSocket__1close
-(JNIEnv *env, jobject obj, jint fd)
+(JNIEnv *env, jclass obj, jint fd)
 {
 	if (close(fd) == -1) {
 		throwIOExceptionErrno(env, errno);


### PR DESCRIPTION
Fix close() mathod parameter type from jobject to jclass,
otherwise a call to close() method results in a following exception:

Exception in thread "main" java.lang.UnsatisfiedLinkError:
de.entropia.can.CanSocket._close(I)V
at de.entropia.can.CanSocket._close(Native Method)
at de.entropia.can.CanSocket.close(CanSocket.java:405)

Reported and fixed by Sandro Anders.

Signed-off-by: Yegor Yefremov yegorslists@googlemail.com
