### PR TITLE
Java 1.6 compatibility, minor tweak to cansocket.cpp to provide better android build support.

### DIFF
--- a/jni/cansocket.cpp
+++ b/jni/cansocket.cpp
@@ -18,12 +18,12 @@ extern "C" {
 }
 
 #if defined(ANDROID) || defined(__ANDROID__)
-#include "jni.h"
 // As of Nov. 2013 the Android-NDK does not build against an updated sys/socket.h
 // AF_CAN and PF_CAN are not defined, causing a compilation error.
 // uncomment the following #define directives to remedy that issue if you're building against an old sys/socket.h
 // #define AF_CAN 29
 // #define PF_CAN AF_CAN
+#include "jni.h"
 #else
 #include "de_entropia_can_CanSocket.h"
 #endif

--- a/jni/cansocket.cpp
+++ b/jni/cansocket.cpp
@@ -19,6 +19,11 @@ extern "C" {
 
 #if defined(ANDROID) || defined(__ANDROID__)
 #include "jni.h"
+// As of Nov. 2013 the Android-NDK does not build against an updated sys/socket.h
+// AF_CAN and PF_CAN are not defined, causing a compilation error.
+// uncomment the following #define directives to remedy that issue if you're building against an old sys/socket.h
+// #define AF_CAN 29
+// #define PF_CAN AF_CAN
 #else
 #include "de_entropia_can_CanSocket.h"
 #endif
@@ -80,6 +85,11 @@ static jint newCanSocket(JNIEnv *env, int socket_type, int protocol)
 	throwIOExceptionErrno(env, errno);
 	return -1;
 }
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 JNIEXPORT jint JNICALL Java_de_entropia_can_CanSocket__1openSocketRAW
 (JNIEnv *env, jclass obj)
@@ -405,3 +415,7 @@ JNIEXPORT jint JNICALL Java_de_entropia_can_CanSocket__1clearERR
 {
 	return canid & ~CAN_ERR_FLAG;
 }
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
CanSocket.java was edited to remove any java 1.6 incompatibilities. Some of cansocket.cpp needed to be conditionally wrapped in an extern "C" block to get the Android-NDK to build the .so file correctly. Also, a comment has been added to guide anyone else building against the Android-NDK, as it uses an old version of sys/socket.h and needs to be manually remedied to build, at least as of this pull request.
