### PR TITLE
Add OSGi support

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -3,5 +3,6 @@ Bundle-ManifestVersion: 2
 Bundle-Name: libsocket-can-java
 Bundle-SymbolicName: libsocket-can-java
 Bundle-Description: SocketCAN JNI wrapper
-Bundle-Version: 1.0.0
+Bundle-Version: 0.1.0
 Export-Package: de.entropia.can
+Import-Package: de.entropia.can

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -1,0 +1,7 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: libsocket-can-java
+Bundle-SymbolicName: libsocket-can-java
+Bundle-Description: SocketCAN JNI wrapper
+Bundle-Version: 1.0.0
+Export-Package: de.entropia.can

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifndef JAVA_HOME
 	JAVA_HOME=$(shell readlink -f /usr/bin/javac | sed "s:bin/javac::")
 endif
 
-JAVA_INCLUDES=-I$(JAVA_HOME)/include
+JAVA_INCLUDES=-I$(JAVA_HOME)/include/linux -I$(JAVA_HOME)/include
 JAVA=$(JAVA_HOME)/bin/java
 JAVAC=$(JAVA_HOME)/bin/javac
 JAVAH=$(JAVA_HOME)/bin/javah

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ stamps/compile-jni: stamps/generate-jni-h $(JNI_SRC)
 		$(sort $(filter %.cpp,$(JNI_SRC)))
 	@touch $@
 
-stamps/create-jar: stamps/compile-jni
+stamps/create-jar: stamps/compile-jni $(JAR_MANIFEST_FILE)
 	$(JAR) cMf $(JAR_DEST_FILE) $(JAR_MANIFEST_FILE) lib -C $(JAVA_DEST) .
 	@touch $@
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ JAVA_TEST_DEST=classes.test
 LIB_DEST=lib
 JAR_DEST=dist
 JAR_DEST_FILE=$(JAR_DEST)/$(NAME).jar
+JAR_MANIFEST_FILE=META-INF/MANIFEST.MF
 DIRS=stamps obj $(JAVA_DEST) $(JAVA_TEST_DEST) $(LIB_DEST) $(JAR_DEST)
 JNI_DIR=jni
 JNI_CLASSES=de.entropia.can.CanSocket
@@ -66,7 +67,7 @@ stamps/compile-jni: stamps/generate-jni-h $(JNI_SRC)
 	@touch $@
 
 stamps/create-jar: stamps/compile-jni
-	$(JAR) cMf $(JAR_DEST_FILE) lib -C $(JAVA_DEST) .
+	$(JAR) cMf $(JAR_DEST_FILE) $(JAR_MANIFEST_FILE) lib -C $(JAVA_DEST) .
 	@touch $@
 
 .PHONY: check

--- a/include/socketcan/can/raw.h
+++ b/include/socketcan/can/raw.h
@@ -24,7 +24,7 @@ enum {
 	CAN_RAW_ERR_FILTER,	/* set filter for error frames       */
 	CAN_RAW_LOOPBACK,	/* local loopback (default:on)       */
 	CAN_RAW_RECV_OWN_MSGS,	/* receive my own msgs (default:off) */
-	CAN_RAW_FD_FRAMES,	/* allow CAN FD frames (default:off) */
+	CAN_RAW_FD_FRAMES	/* allow CAN FD frames (default:off) */
 };
 
 #endif


### PR DESCRIPTION
I need to use libsocket-can-java in an OSGi environment, and that requires adding a manifest file. The JAR file will remain working in non-OSGi environments.

Also, note that if there are updates to the library, the version number in the manifest needs to be increased.
